### PR TITLE
Replacing drush with bundled install.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,6 @@ before_script:
   - sudo cp $HOME/.phpenv/versions/`php -r "print PHP_VERSION;"`/etc/php-fpm.conf.default $HOME/.phpenv/versions/`php -r "print PHP_VERSION;"`/etc/php-fpm.conf
   - $HOME/.phpenv/versions/`php -r "print PHP_VERSION;"`/sbin/php-fpm
 
-  # Install Drush. Newer drush versions won't run site-install because Backdrop
-  # doesn't match expectations about Drupal 7/8 versions. Drush 5.7 doesn't
-  # check the version at all, so it works for now.
-  - pear channel-discover pear.drush.org
-  - pear install drush/drush-5.7.0
-  - phpenv rehash
-
   # Import the PHP configuration.
   - phpenv config-add core/misc/travis-ci/php.ini
 
@@ -53,10 +46,9 @@ before_script:
 
   # Install Backdrop with Drush.
   - chmod a+w sites/default
-  - drush si --db-url=mysql://travis:@localhost/backdrop -y
+  - ./core/scripts/install.sh --db-url=mysql://travis:@localhost/backdrop
   - chmod go-w sites/default
-  - drush en simpletest -y
-script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color XML-RPC
+script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --force XML-RPC
 after_failure:
   - echo "Failures detected. Outputing additional logs:"
   - sudo cat /var/log/apache2/error.log


### PR DESCRIPTION
We can't keep using Drush 5.7 forever, this removes the dependency until we can add official Backdrop support to Drush.

https://github.com/backdrop/backdrop-issues/issues/118
https://github.com/backdrop/backdrop/pull/91
